### PR TITLE
Fixed url to link to the open source projet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies=[
     "haversine",
     "typing-inspect>=0.8.0",
     "typing_extensions>=4.5.0",
-    'railjson_generator @ git+ssh://git@github.com/osrd-project/osrd.git@v0.2.13#subdirectory=python/railjson_generator',  # noqa
+    'railjson_generator @ git+ssh://git@github.com/OpenRailAssociation/osrd.git@v0.2.13#subdirectory=python/railjson_generator',  # noqa
     'ipython',
     'distinctipy',
 ]


### PR DESCRIPTION
The pyproject.toml was referencing an old url that required private access whereas the new one is truely open source.